### PR TITLE
fix: add typedoc as a devDependency in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "devDependencies": {
     "@types/bun": "latest",
     "@vitest/coverage-v8": "3.1.2",
+    "typedoc": "^0.28.4",
     "vite": "^6.3.4",
     "vitest": "^3.1.2"
   },


### PR DESCRIPTION
This pull request introduces a small change to the `package.json` file by adding `typedoc` as a new development dependency. This will enable the generation of TypeScript documentation for the project.